### PR TITLE
キーワードなし検索

### DIFF
--- a/nicovideo_api_client/api/v2/filter.py
+++ b/nicovideo_api_client/api/v2/filter.py
@@ -31,6 +31,8 @@ class SnapshotSearchAPIV2Filter:
         self._query["jsonFilter"] = urllib.parse.quote_plus(
             JSONEncoder().encode(op.json)
         )
-        if self._query["q"] == "":
+        if "q" not in self._query:
+            raise Exception("キーワードが指定されていません")
+        elif self._query["q"] == "":
             raise Exception("JSONフィルタでキーワードなし検索を行うことはできません")
         return SnapshotSearchAPIV2Limit(self._query)

--- a/nicovideo_api_client/api/v2/filter.py
+++ b/nicovideo_api_client/api/v2/filter.py
@@ -32,7 +32,7 @@ class SnapshotSearchAPIV2Filter:
             JSONEncoder().encode(op.json)
         )
         if "q" not in self._query:
-            raise Exception("キーワードが指定されていません")
+            raise KeyError("キーワードが指定されていません")
         elif self._query["q"] == "":
-            raise Exception("JSONフィルタでキーワードなし検索を行うことはできません")
+            raise ValueError("JSONフィルタでキーワードなし検索を行うことはできません")
         return SnapshotSearchAPIV2Limit(self._query)

--- a/nicovideo_api_client/api/v2/filter.py
+++ b/nicovideo_api_client/api/v2/filter.py
@@ -31,4 +31,6 @@ class SnapshotSearchAPIV2Filter:
         self._query["jsonFilter"] = urllib.parse.quote_plus(
             JSONEncoder().encode(op.json)
         )
+        if self._query["q"] == "":
+            raise Exception("JSONフィルタでキーワードなし検索を行うことはできません")
         return SnapshotSearchAPIV2Limit(self._query)

--- a/nicovideo_api_client/api/v2/simple_filter.py
+++ b/nicovideo_api_client/api/v2/simple_filter.py
@@ -131,8 +131,9 @@ class SnapshotSearchAPIV2SimpleFilter:
             #範囲検索の場合: filter(RangeDict型の辞書, False)
             #複合検索の場合: filter(CombinedDict型の辞書, True)
         """
-
-        if value is not None:
+        if self._query["q"] == "" and value is None:
+            raise Exception("キーワード無し検索を行う場合には必ず検索フィルタを指定してください")
+        elif value is not None:
             if type(value) is not dict:
                 raise TypeError("検索にはMatchDictまたはRangeDictどちらかの型を指定する必要があります")
             elif combine is True:

--- a/nicovideo_api_client/api/v2/targets.py
+++ b/nicovideo_api_client/api/v2/targets.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict
 
 from nicovideo_api_client.api.v2.field import SnapshotSearchAPIV2Fields
 from nicovideo_api_client.constants import FieldType

--- a/nicovideo_api_client/api/v2/targets.py
+++ b/nicovideo_api_client/api/v2/targets.py
@@ -13,7 +13,9 @@ class SnapshotSearchAPIV2Targets:
             "targets": ",".join(map(lambda x: x.value, list_targets))
         }
 
-    def query(self, keyword: Optional[str] = "") -> SnapshotSearchAPIV2Fields:
+    def query(
+        self, keyword: str, no_keyword: Optional[bool] = False
+    ) -> SnapshotSearchAPIV2Fields:
         """
         検索クエリ(キーワード)を指定する。
 
@@ -23,9 +25,12 @@ class SnapshotSearchAPIV2Targets:
 
         TODO: AND・OR検索を実装する
 
-        :param keyword: 検索するキーワード
+        :param
+            keyword: 検索するキーワード
+            no_keyword: キーワードなし検索を行う場合のフラグ。デフォルト値はFalse
         :return: レスポンスフィールドのタイプ指定オブジェクト
         """
-
+        if keyword == "" and no_keyword is False:
+            raise Exception("キーワードなし検索を行うには第2引数にTrueを指定する必要があります")
         self._query["q"] = keyword
         return SnapshotSearchAPIV2Fields(self._query)

--- a/nicovideo_api_client/api/v2/targets.py
+++ b/nicovideo_api_client/api/v2/targets.py
@@ -13,9 +13,7 @@ class SnapshotSearchAPIV2Targets:
             "targets": ",".join(map(lambda x: x.value, list_targets))
         }
 
-    def query(
-        self, keyword: str, no_keyword: Optional[bool] = False
-    ) -> SnapshotSearchAPIV2Fields:
+    def query(self, keyword: str) -> SnapshotSearchAPIV2Fields:
         """
         検索クエリ(キーワード)を指定する。
 
@@ -27,10 +25,23 @@ class SnapshotSearchAPIV2Targets:
 
         :param
             keyword: 検索するキーワード
-            no_keyword: キーワードなし検索を行う場合のフラグ。デフォルト値はFalse
         :return: レスポンスフィールドのタイプ指定オブジェクト
         """
-        if keyword == "" and no_keyword is False:
-            raise Exception("キーワードなし検索を行うには第2引数にTrueを指定する必要があります")
+        if keyword == "":
+            raise Exception("キーワードなし検索を行うにはno_keywordメソッドを指定する必要があります")
         self._query["q"] = keyword
+        return SnapshotSearchAPIV2Fields(self._query)
+
+    def no_keyword(self) -> SnapshotSearchAPIV2Fields:
+        """
+        キーワードなし検索を行う。
+
+        `クエリ文字列仕様 <https://site.nicovideo.jp/search-api-docs/snapshot#%EF%BC%8A1-
+        %E3%82%AF%E3%82%A8%E3%83%AA%E6%96%87%E5%AD%97%E5%88%97%E4%BB%95%E6%A7%98>`_
+        q=自体の省略はできません。
+        負荷の高い検索となりますので、filtersと併用しヒット件数を10万件以内に絞り込んだ上でご利用ください。
+
+        :return: レスポンスフィールドのタイプ指定オブジェクト
+        """
+        self._query["q"] = ""
         return SnapshotSearchAPIV2Fields(self._query)

--- a/nicovideo_api_client/api/v2/targets.py
+++ b/nicovideo_api_client/api/v2/targets.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 from nicovideo_api_client.api.v2.field import SnapshotSearchAPIV2Fields
 from nicovideo_api_client.constants import FieldType
@@ -13,7 +13,7 @@ class SnapshotSearchAPIV2Targets:
             "targets": ",".join(map(lambda x: x.value, list_targets))
         }
 
-    def query(self, keyword: str) -> SnapshotSearchAPIV2Fields:
+    def query(self, keyword: Optional[str] = "") -> SnapshotSearchAPIV2Fields:
         """
         検索クエリ(キーワード)を指定する。
 
@@ -26,5 +26,6 @@ class SnapshotSearchAPIV2Targets:
         :param keyword: 検索するキーワード
         :return: レスポンスフィールドのタイプ指定オブジェクト
         """
+
         self._query["q"] = keyword
         return SnapshotSearchAPIV2Fields(self._query)

--- a/tests/v2/test_json_filter.py
+++ b/tests/v2/test_json_filter.py
@@ -18,7 +18,7 @@ class JsonFilterTestCase(unittest.TestCase):
     )
 
     def test_set_range_time(self):
-        actual = SnapshotSearchAPIV2Filter({}).json_filter(self.term_time)
+        actual = SnapshotSearchAPIV2Filter({"q": "test"}).json_filter(self.term_time)
         assert (
             actual._query["jsonFilter"]
             == "%7B%22type%22%3A+%22range%22%2C+%22field%22%3A+%22startTime%22%2C"
@@ -28,7 +28,7 @@ class JsonFilterTestCase(unittest.TestCase):
         )
 
     def test_set_range_view(self):
-        actual = SnapshotSearchAPIV2Filter({}).json_filter(self.term_view)
+        actual = SnapshotSearchAPIV2Filter({"q": "test"}).json_filter(self.term_view)
         assert (
             actual._query["jsonFilter"]
             == "%7B%22type%22%3A+%22range%22%2C+%22field%22%3A+%22viewCounter%22%2C"
@@ -37,7 +37,7 @@ class JsonFilterTestCase(unittest.TestCase):
         )
 
     def test_not(self):
-        actual = SnapshotSearchAPIV2Filter({}).json_filter(
+        actual = SnapshotSearchAPIV2Filter({"q": "test"}).json_filter(
             JsonFilterOperator.not_(self.term_view)
         )
         assert (
@@ -49,7 +49,7 @@ class JsonFilterTestCase(unittest.TestCase):
         )
 
     def test_or(self):
-        actual = SnapshotSearchAPIV2Filter({}).json_filter(
+        actual = SnapshotSearchAPIV2Filter({"q": "test"}).json_filter(
             JsonFilterOperator.or_(self.term_view, self.term_time)
         )
         assert (
@@ -65,7 +65,7 @@ class JsonFilterTestCase(unittest.TestCase):
         )
 
     def test_and(self):
-        actual = SnapshotSearchAPIV2Filter({}).json_filter(
+        actual = SnapshotSearchAPIV2Filter({"q": "test"}).json_filter(
             JsonFilterOperator.and_(self.term_view, self.term_time)
         )
         assert (
@@ -81,7 +81,7 @@ class JsonFilterTestCase(unittest.TestCase):
         )
 
     def test_nested(self):
-        actual = SnapshotSearchAPIV2Filter({}).json_filter(
+        actual = SnapshotSearchAPIV2Filter({"q": "test"}).json_filter(
             JsonFilterOperator.or_(
                 JsonFilterOperator.not_(self.term_view), self.term_time
             )
@@ -97,6 +97,24 @@ class JsonFilterTestCase(unittest.TestCase):
             "+%222021-12-31T00%3A00%3A00%2B09%3A00%22%2C+%22include_lower%22%3A"
             "+true%2C+%22include_upper%22%3A+true%7D%5D%7D"
         )
+
+    def test_keyword_undefined(self):
+        with self.assertRaises(Exception) as error:
+            SnapshotSearchAPIV2Filter({}).json_filter(
+                JsonFilterOperator.or_(
+                    JsonFilterOperator.not_(self.term_view), self.term_time
+                )
+            )
+        self.assertEqual(error.exception.args[0], "キーワードが指定されていません")
+
+    def test_no_keyword(self):
+        with self.assertRaises(Exception) as error:
+            SnapshotSearchAPIV2Filter({"q": ""}).json_filter(
+                JsonFilterOperator.or_(
+                    JsonFilterOperator.not_(self.term_view), self.term_time
+                )
+            )
+        self.assertEqual(error.exception.args[0], "JSONフィルタでキーワードなし検索を行うことはできません")
 
 
 if __name__ == "__main__":

--- a/tests/v2/test_json_filter.py
+++ b/tests/v2/test_json_filter.py
@@ -99,7 +99,7 @@ class JsonFilterTestCase(unittest.TestCase):
         )
 
     def test_keyword_undefined(self):
-        with self.assertRaises(Exception) as error:
+        with self.assertRaises(KeyError) as error:
             SnapshotSearchAPIV2Filter({}).json_filter(
                 JsonFilterOperator.or_(
                     JsonFilterOperator.not_(self.term_view), self.term_time
@@ -108,7 +108,7 @@ class JsonFilterTestCase(unittest.TestCase):
         self.assertEqual(error.exception.args[0], "キーワードが指定されていません")
 
     def test_no_keyword(self):
-        with self.assertRaises(Exception) as error:
+        with self.assertRaises(ValueError) as error:
             SnapshotSearchAPIV2Filter({"q": ""}).json_filter(
                 JsonFilterOperator.or_(
                     JsonFilterOperator.not_(self.term_view), self.term_time


### PR DESCRIPTION
#8 
targets.pyのqueryメソッドの引数にフラグ用引数を追加し、これがTrueになっていない時に空文字を指定した場合にエラー処理。
また、simple_filter.pyのfilterメソッドでは、query["q"]が空文字であり且つフィルタが指定されていないときにはフィルターを指定するように促すエラー処理を実装。