### PR TITLE
json_filterの共通化関数set_rangeを実装

### DIFF
--- a/examples/json_filter.py
+++ b/examples/json_filter.py
@@ -15,10 +15,14 @@ def main():
         .sort(FieldType.VIEW_COUNTER)
         .json_filter(
             JsonFilterOperator.or_(
-                JsonFilterTerm.set_range_time(
-                    from_=datetime(2021, 1, 1, 0, 0, 0), include_lower=True
+                JsonFilterTerm.set_range(
+                    FieldType.START_TIME,
+                    from_=datetime(2021, 1, 1, 0, 0, 0),
+                    include_lower=True,
                 ),
-                JsonFilterTerm.set_range_time(to_=datetime(2010, 1, 1, 0, 0, 0)),
+                JsonFilterTerm.set_range(
+                    FieldType.START_TIME, to_=datetime(2010, 1, 1, 0, 0, 0)
+                ),
             )
         )
         .limit(10)

--- a/nicovideo_api_client/api/v2/json_filter.py
+++ b/nicovideo_api_client/api/v2/json_filter.py
@@ -115,19 +115,37 @@ class JsonFilterTerm(JsonFilterOperator):
                 | FieldType.COMMENT_COUNTER
             ):
                 if from_ is not None:
-                    json_["from"] = from_
+                    if type(from_) is int:
+                        json_["from"] = from_
+                    else:
+                        raise TypeError(
+                            f"フィールド {field_type.value} には int が指定されるべきです"
+                        )
                 if to_ is not None:
-                    json_["to"] = to_
-
+                    if type(to_) is int:
+                        json_["to"] = to_
+                    else:
+                        raise TypeError(
+                            f"フィールド {field_type.value} には int が指定されるべきです"
+                        )
             case (
                 FieldType.START_TIME
                 | FieldType.LAST_COMMENT_TIME
             ):
                 if from_ is not None:
-                    json_["from"] = from_.strftime("%Y-%m-%dT%H:%M:%S+09:00")
+                    if type(from_) is datetime:
+                        json_["from"] = from_.strftime("%Y-%m-%dT%H:%M:%S+09:00")
+                    else:
+                        raise TypeError(
+                            f"フィールド {field_type.value} には datetime が指定されるべきです"
+                        )
                 if to_ is not None:
-                    json_["to"] = to_.strftime("%Y-%m-%dT%H:%M:%S+09:00")
-
+                    if type(to_) is datetime:
+                        json_["to"] = to_.strftime("%Y-%m-%dT%H:%M:%S+09:00")
+                    else:
+                        raise TypeError(
+                            f"フィールド {field_type.value} には datetime が指定されるべきです"
+                        )
             case _:
                 raise TypeError(
                     f"{field_type.value}はjson_filterに指定できないフィールドです"

--- a/nicovideo_api_client/api/v2/json_filter.py
+++ b/nicovideo_api_client/api/v2/json_filter.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Type
 from nicovideo_api_client.constants import FieldType
 
 TypeOp = Dict[str, Union[str, bool, int, List["TypeOp"], "TypeOp"]]
@@ -125,22 +125,26 @@ class JsonFilterTerm(JsonFilterOperator):
                 | FieldType.COMMENT_COUNTER
             ):
                 if from_ is not None:
-                    json_["from"] = JsonFilterTerm\
-                        .__arrange_value(from_, int, field_type)
+                    json_["from"] = JsonFilterTerm.__arrange_value(
+                        from_, int, field_type
+                    )
                 if to_ is not None:
-                    json_["to"] = JsonFilterTerm\
-                        .__arrange_value(to_, int, field_type)
+                    json_["to"] = JsonFilterTerm.__arrange_value(
+                        to_, int, field_type
+                    )
             case (
                 FieldType.START_TIME
                 | FieldType.LAST_COMMENT_TIME
             ):
                 if from_ is not None:
-                    json_["from"] = JsonFilterTerm\
-                        .__arrange_value(from_, datetime, field_type)
+                    json_["from"] = JsonFilterTerm.__arrange_value(
+                        from_, datetime, field_type
+                    )
 
                 if to_ is not None:
-                    json_["to"] = JsonFilterTerm\
-                        .__arrange_value(to_, datetime, field_type)
+                    json_["to"] = JsonFilterTerm.__arrange_value(
+                        to_, datetime, field_type
+                    )
             case _:
                 raise TypeError(
                     f"{field_type.value}はjson_filterに指定できないフィールドです"
@@ -153,18 +157,12 @@ class JsonFilterTerm(JsonFilterOperator):
         return term
 
     @staticmethod
-    def __arrange_value(value: Union[int, datetime], type_: type, field_type: FieldType):
-        if type_ is int:
-            if type(value) is not int:
-                raise TypeError(
-                    f"フィールド {field_type.value} には {type_} が指定されるべきです"
-                )
+    def __arrange_value(value: Union[int, datetime], type_: Type[Union[int, datetime]], field_type: FieldType):
+        if type_ is int and type(value) is type_:
             return value
-        elif type_ is datetime:
-            if type(value) is not datetime:
-                raise TypeError(
-                    f"フィールド {field_type.value} には {type_} が指定されるべきです"
-                )
+        elif type_ is datetime and type(value) is type_:
             return value.strftime("%Y-%m-%dT%H:%M:%S+09:00")
         else:
-            raise Exception("type_ には \"int\" または \"datetime\" が指定されるべきです")
+            raise TypeError(
+                f"フィールド {field_type.value} には {type_} が指定されるべきです"
+            )

--- a/nicovideo_api_client/api/v2/json_filter.py
+++ b/nicovideo_api_client/api/v2/json_filter.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Dict, List, Optional, Union
+from nicovideo_api_client.constants import FieldType
 
 TypeOp = Dict[str, Union[str, bool, int, List["TypeOp"], "TypeOp"]]
 
@@ -88,63 +89,49 @@ class JsonFilterTerm(JsonFilterOperator):
         super().__init__({})
 
     @staticmethod
-    def set_range_view(
-        from_: Optional[int] = None,
-        to_: Optional[int] = None,
+    def set_range(
+        field_type: FieldType,
+        from_: Optional[Union[int, datetime]] = None,
+        to_: Optional[Union[int, datetime]] = None,
         include_lower: bool = True,
         include_upper: bool = True,
     ) -> "JsonFilterTerm":
-        """
-        再生回数が与えられた範囲内かを調べる検索要素。
-
-        :param from_: 再生回数の下限
-        :param to_: 再生回数の上限
-        :param include_lower: from_ を含むかどうか
-        :param include_upper: to_ を含むかどうか
-        :return: 絞り込み要素オブジェクト
-        """
         term: JsonFilterTerm = JsonFilterTerm()
         if from_ is None and to_ is None:
             raise Exception("上限も下限も指定されていません")
         json_: Dict[str, Union[str, bool, int]] = {
             "type": "range",
-            "field": "viewCounter",
+            "field": field_type.value,
         }
-        if from_ is not None:
-            json_["from"] = from_
-        if to_ is not None:
-            json_["to"] = to_
-        if include_lower:
-            json_["include_lower"] = include_lower
-        if include_upper:
-            json_["include_upper"] = include_upper
-        term.json = json_
-        return term
 
-    @staticmethod
-    def set_range_time(
-        from_: Optional[datetime] = None,
-        to_: Optional[datetime] = None,
-        include_lower: bool = True,
-        include_upper: bool = True,
-    ) -> "JsonFilterTerm":
-        """
-        投稿時刻が与えられた範囲内かを調べる検索要素。
+        match field_type:
+            case (
+                FieldType.USER_ID
+                | FieldType.CHANNEL_ID
+                | FieldType.VIEW_COUNTER
+                | FieldType.MYLIST_COUNTER
+                | FieldType.LIKE_COUNTER
+                | FieldType.LENGTH_SECONDS
+                | FieldType.COMMENT_COUNTER
+            ):
+                if from_ is not None:
+                    json_["from"] = from_
+                if to_ is not None:
+                    json_["to"] = to_
 
-        :param from_: 投稿時刻の最古
-        :param to_: 投稿時刻の最新
-        :param include_lower: from_ を含むかどうか
-        :param include_upper: to_ を含むかどうか
-        :return: 絞り込み要素オブジェクト
-        """
-        term: JsonFilterTerm = JsonFilterTerm()
-        if from_ is None and to_ is None:
-            raise Exception("開始時刻も終了時刻も指定されていません")
-        json_: Dict[str, Union[str, bool]] = {"type": "range", "field": "startTime"}
-        if from_ is not None:
-            json_["from"] = from_.strftime("%Y-%m-%dT%H:%M:%S+09:00")
-        if to_ is not None:
-            json_["to"] = to_.strftime("%Y-%m-%dT%H:%M:%S+09:00")
+            case (
+                FieldType.START_TIME
+                | FieldType.LAST_COMMENT_TIME
+            ):
+                if from_ is not None:
+                    json_["from"] = from_.strftime("%Y-%m-%dT%H:%M:%S+09:00")
+                if to_ is not None:
+                    json_["to"] = to_.strftime("%Y-%m-%dT%H:%M:%S+09:00")
+
+            case _:
+                raise TypeError(
+                    f"{field_type.value}はjson_filterに指定できないフィールドです"
+                )
         if include_lower:
             json_["include_lower"] = include_lower
         if include_upper:

--- a/nicovideo_api_client/api/v2/json_filter.py
+++ b/nicovideo_api_client/api/v2/json_filter.py
@@ -125,11 +125,11 @@ class JsonFilterTerm(JsonFilterOperator):
                 | FieldType.COMMENT_COUNTER
             ):
                 if from_ is not None:
-                    json_["from"] = JsonFilterTerm.__arrange_value(
+                    json_["from"] = JsonFilterTerm._arrange_value(
                         from_, int, field_type
                     )
                 if to_ is not None:
-                    json_["to"] = JsonFilterTerm.__arrange_value(
+                    json_["to"] = JsonFilterTerm._arrange_value(
                         to_, int, field_type
                     )
             case (
@@ -137,12 +137,12 @@ class JsonFilterTerm(JsonFilterOperator):
                 | FieldType.LAST_COMMENT_TIME
             ):
                 if from_ is not None:
-                    json_["from"] = JsonFilterTerm.__arrange_value(
+                    json_["from"] = JsonFilterTerm._arrange_value(
                         from_, datetime, field_type
                     )
 
                 if to_ is not None:
-                    json_["to"] = JsonFilterTerm.__arrange_value(
+                    json_["to"] = JsonFilterTerm._arrange_value(
                         to_, datetime, field_type
                     )
             case _:
@@ -157,15 +157,16 @@ class JsonFilterTerm(JsonFilterOperator):
         return term
 
     @staticmethod
-    def __arrange_value(
+    def _arrange_value(
         value: Union[int, datetime],
-        type_: Type[Union[int, datetime]],
+        type_: Union[Type[int], Type[datetime]],
         field_type: FieldType,
     ):
-        if type_ is int and type(value) is type_:
-            return value
-        elif type_ is datetime and type(value) is type_:
-            return value.strftime("%Y-%m-%dT%H:%M:%S+09:00")
+        if type(value) is type_:
+            if type_ is int:
+                return value
+            elif type_ is datetime:
+                return value.strftime("%Y-%m-%dT%H:%M:%S+09:00")
         else:
             raise TypeError(
                 f"フィールド {field_type.value} には {type_} が指定されるべきです"

--- a/nicovideo_api_client/api/v2/json_filter.py
+++ b/nicovideo_api_client/api/v2/json_filter.py
@@ -157,7 +157,11 @@ class JsonFilterTerm(JsonFilterOperator):
         return term
 
     @staticmethod
-    def __arrange_value(value: Union[int, datetime], type_: Type[Union[int, datetime]], field_type: FieldType):
+    def __arrange_value(
+        value: Union[int, datetime],
+        type_: Type[Union[int, datetime]],
+        field_type: FieldType,
+    ):
         if type_ is int and type(value) is type_:
             return value
         elif type_ is datetime and type(value) is type_:

--- a/nicovideo_api_client/api/v2/json_filter.py
+++ b/nicovideo_api_client/api/v2/json_filter.py
@@ -88,8 +88,8 @@ class JsonFilterTerm(JsonFilterOperator):
     def __init__(self):
         super().__init__({})
 
+    @staticmethod
     def set_range(
-        self,
         field_type: FieldType,
         from_: Optional[Union[int, datetime]] = None,
         to_: Optional[Union[int, datetime]] = None,
@@ -125,18 +125,18 @@ class JsonFilterTerm(JsonFilterOperator):
                 | FieldType.COMMENT_COUNTER
             ):
                 if from_ is not None:
-                    json_["from"] = self.__arrange_value(from_, "int", field_type)
+                    json_["from"] = JsonFilterTerm.__arrange_value(from_, int, field_type)
                 if to_ is not None:
-                    json_["to"] = self.__arrange_value(to_, "int", field_type)
+                    json_["to"] = JsonFilterTerm.__arrange_value(to_, int, field_type)
             case (
                 FieldType.START_TIME
                 | FieldType.LAST_COMMENT_TIME
             ):
                 if from_ is not None:
-                    json_["from"] = self.__arrange_value(from_, "datetime", field_type)
+                    json_["from"] = JsonFilterTerm.__arrange_value(from_, datetime, field_type)
 
                 if to_ is not None:
-                    json_["to"] = self.__arrange_value(to_, "datetime", field_type)
+                    json_["to"] = JsonFilterTerm.__arrange_value(to_, datetime, field_type)
             case _:
                 raise TypeError(
                     f"{field_type.value}はjson_filterに指定できないフィールドです"
@@ -149,19 +149,18 @@ class JsonFilterTerm(JsonFilterOperator):
         return term
 
     @staticmethod
-    def __arrange_value(value: Union[int, datetime], type_: str, field_type: FieldType):
-        match type_:
-            case "int":
-                if type(value) is not int:
-                    raise TypeError(
-                        f"フィールド {field_type.value} には {type_} が指定されるべきです"
-                    )
-                return value
-            case "datetime":
-                if type(value) is not datetime:
-                    raise TypeError(
-                        f"フィールド {field_type.value} には {type_} が指定されるべきです"
-                    )
-                return value.strftime("%Y-%m-%dT%H:%M:%S+09:00")
-            case _:
-                raise Exception("type_ には \"int\" または \"datetime\" が指定されるべきです")
+    def __arrange_value(value: Union[int, datetime], type_: type, field_type: FieldType):
+        if type_ is int:
+            if type(value) is not int:
+                raise TypeError(
+                    f"フィールド {field_type.value} には {type_} が指定されるべきです"
+                )
+            return value
+        elif type_ is datetime:
+            if type(value) is not datetime:
+                raise TypeError(
+                    f"フィールド {field_type.value} には {type_} が指定されるべきです"
+                )
+            return value.strftime("%Y-%m-%dT%H:%M:%S+09:00")
+        else:
+            raise Exception("type_ には \"int\" または \"datetime\" が指定されるべきです")

--- a/nicovideo_api_client/api/v2/json_filter.py
+++ b/nicovideo_api_client/api/v2/json_filter.py
@@ -88,8 +88,8 @@ class JsonFilterTerm(JsonFilterOperator):
     def __init__(self):
         super().__init__({})
 
-    @staticmethod
     def set_range(
+        self,
         field_type: FieldType,
         from_: Optional[Union[int, datetime]] = None,
         to_: Optional[Union[int, datetime]] = None,
@@ -125,37 +125,18 @@ class JsonFilterTerm(JsonFilterOperator):
                 | FieldType.COMMENT_COUNTER
             ):
                 if from_ is not None:
-                    if type(from_) is int:
-                        json_["from"] = from_
-                    else:
-                        raise TypeError(
-                            f"フィールド {field_type.value} には int が指定されるべきです"
-                        )
+                    json_["from"] = self.__arrange_value(from_, "int", field_type)
                 if to_ is not None:
-                    if type(to_) is int:
-                        json_["to"] = to_
-                    else:
-                        raise TypeError(
-                            f"フィールド {field_type.value} には int が指定されるべきです"
-                        )
+                    json_["to"] = self.__arrange_value(to_, "int", field_type)
             case (
                 FieldType.START_TIME
                 | FieldType.LAST_COMMENT_TIME
             ):
                 if from_ is not None:
-                    if type(from_) is datetime:
-                        json_["from"] = from_.strftime("%Y-%m-%dT%H:%M:%S+09:00")
-                    else:
-                        raise TypeError(
-                            f"フィールド {field_type.value} には datetime が指定されるべきです"
-                        )
+                    json_["from"] = self.__arrange_value(from_, "datetime", field_type)
+
                 if to_ is not None:
-                    if type(to_) is datetime:
-                        json_["to"] = to_.strftime("%Y-%m-%dT%H:%M:%S+09:00")
-                    else:
-                        raise TypeError(
-                            f"フィールド {field_type.value} には datetime が指定されるべきです"
-                        )
+                    json_["to"] = self.__arrange_value(to_, "datetime", field_type)
             case _:
                 raise TypeError(
                     f"{field_type.value}はjson_filterに指定できないフィールドです"
@@ -166,3 +147,21 @@ class JsonFilterTerm(JsonFilterOperator):
             json_["include_upper"] = include_upper
         term.json = json_
         return term
+
+    @staticmethod
+    def __arrange_value(value: Union[int, datetime], type_: str, field_type: FieldType):
+        match type_:
+            case "int":
+                if type(value) is not int:
+                    raise TypeError(
+                        f"フィールド {field_type.value} には {type_} が指定されるべきです"
+                    )
+                return value
+            case "datetime":
+                if type(value) is not datetime:
+                    raise TypeError(
+                        f"フィールド {field_type.value} には {type_} が指定されるべきです"
+                    )
+                return value.strftime("%Y-%m-%dT%H:%M:%S+09:00")
+            case _:
+                raise Exception("type_ には \"int\" または \"datetime\" が指定されるべきです")

--- a/nicovideo_api_client/api/v2/json_filter.py
+++ b/nicovideo_api_client/api/v2/json_filter.py
@@ -129,13 +129,8 @@ class JsonFilterTerm(JsonFilterOperator):
                         from_, int, field_type
                     )
                 if to_ is not None:
-                    json_["to"] = JsonFilterTerm._arrange_value(
-                        to_, int, field_type
-                    )
-            case (
-                FieldType.START_TIME
-                | FieldType.LAST_COMMENT_TIME
-            ):
+                    json_["to"] = JsonFilterTerm._arrange_value(to_, int, field_type)
+            case (FieldType.START_TIME | FieldType.LAST_COMMENT_TIME):
                 if from_ is not None:
                     json_["from"] = JsonFilterTerm._arrange_value(
                         from_, datetime, field_type
@@ -146,9 +141,7 @@ class JsonFilterTerm(JsonFilterOperator):
                         to_, datetime, field_type
                     )
             case _:
-                raise TypeError(
-                    f"{field_type.value}はjson_filterに指定できないフィールドです"
-                )
+                raise TypeError(f"{field_type.value}はjson_filterに指定できないフィールドです")
         if include_lower:
             json_["include_lower"] = include_lower
         if include_upper:
@@ -161,13 +154,11 @@ class JsonFilterTerm(JsonFilterOperator):
         value: Union[int, datetime],
         type_: Union[Type[int], Type[datetime]],
         field_type: FieldType,
-    ):
+    ) -> Union[int, str]:
         if type(value) is type_:
             if type_ is int:
                 return value
             elif type_ is datetime:
                 return value.strftime("%Y-%m-%dT%H:%M:%S+09:00")
         else:
-            raise TypeError(
-                f"フィールド {field_type.value} には {type_} が指定されるべきです"
-            )
+            raise TypeError(f"フィールド {field_type.value} には {type_} が指定されるべきです")

--- a/nicovideo_api_client/api/v2/json_filter.py
+++ b/nicovideo_api_client/api/v2/json_filter.py
@@ -125,18 +125,22 @@ class JsonFilterTerm(JsonFilterOperator):
                 | FieldType.COMMENT_COUNTER
             ):
                 if from_ is not None:
-                    json_["from"] = JsonFilterTerm.__arrange_value(from_, int, field_type)
+                    json_["from"] = JsonFilterTerm\
+                        .__arrange_value(from_, int, field_type)
                 if to_ is not None:
-                    json_["to"] = JsonFilterTerm.__arrange_value(to_, int, field_type)
+                    json_["to"] = JsonFilterTerm\
+                        .__arrange_value(to_, int, field_type)
             case (
                 FieldType.START_TIME
                 | FieldType.LAST_COMMENT_TIME
             ):
                 if from_ is not None:
-                    json_["from"] = JsonFilterTerm.__arrange_value(from_, datetime, field_type)
+                    json_["from"] = JsonFilterTerm\
+                        .__arrange_value(from_, datetime, field_type)
 
                 if to_ is not None:
-                    json_["to"] = JsonFilterTerm.__arrange_value(to_, datetime, field_type)
+                    json_["to"] = JsonFilterTerm\
+                        .__arrange_value(to_, datetime, field_type)
             case _:
                 raise TypeError(
                     f"{field_type.value}はjson_filterに指定できないフィールドです"

--- a/nicovideo_api_client/api/v2/json_filter.py
+++ b/nicovideo_api_client/api/v2/json_filter.py
@@ -96,6 +96,16 @@ class JsonFilterTerm(JsonFilterOperator):
         include_lower: bool = True,
         include_upper: bool = True,
     ) -> "JsonFilterTerm":
+        """
+        検索フィールドについて、与えられた数値または日付の範囲内かを調べる検索要素。
+
+        :param field_type: 検索するフィールド
+        :param from_: 数値の下限または投稿時刻の最古
+        :param to_: 数値の上限または投稿時刻の最新
+        :param include_lower: from_ を含むかどうか
+        :param include_upper: to_ を含むかどうか
+        :return: 絞り込み要素オブジェクト
+        """
         term: JsonFilterTerm = JsonFilterTerm()
         if from_ is None and to_ is None:
             raise Exception("上限も下限も指定されていません")

--- a/poetry.lock
+++ b/poetry.lock
@@ -41,7 +41,7 @@ pytz = ">=2015.7"
 
 [[package]]
 name = "black"
-version = "21.10b0"
+version = "21.11b1"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false

--- a/poetry.lock
+++ b/poetry.lock
@@ -579,6 +579,7 @@ babel = [
 black = [
     {file = "black-21.10b0-py3-none-any.whl", hash = "sha256:6eb7448da9143ee65b856a5f3676b7dda98ad9abe0f87fce8c59291f15e82a5b"},
     {file = "black-21.10b0.tar.gz", hash = "sha256:a9952229092e325fe5f3dae56d81f639b23f7131eb840781947e4b2886030f33"},
+    {file = "black-21.11b1.tar.gz", hash = "sha256:a042adbb18b3262faad5aff4e834ff186bb893f95ba3a8013f09de1e5569def2"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ Sphinx = "^4.2.0"
 taskipy = "^1.8.2"
 pyproject-flake8 = "^0.0.1-alpha.2"
 install = "^1.3.4"
-black = "^21.10b0"
+black = "^21.11b1"
 isort = "5.10.1"
 
 [build-system]

--- a/tests/v2/test_json_filter.py
+++ b/tests/v2/test_json_filter.py
@@ -7,7 +7,7 @@ from nicovideo_api_client.constants import FieldType
 
 
 class JsonFilterTestCase(unittest.TestCase):
-    term_time = JsonFilterTerm().set_range(
+    term_time = JsonFilterTerm.set_range(
         field_type=FieldType.START_TIME,
         from_=datetime(2021, 1, 1),
         to_=datetime(2021, 12, 31),
@@ -15,7 +15,7 @@ class JsonFilterTestCase(unittest.TestCase):
         include_lower=True,
     )
 
-    term_view = JsonFilterTerm().set_range(
+    term_view = JsonFilterTerm.set_range(
         field_type=FieldType.VIEW_COUNTER,
         from_=100,
         to_=1000,

--- a/tests/v2/test_json_filter.py
+++ b/tests/v2/test_json_filter.py
@@ -3,18 +3,24 @@ from datetime import datetime
 
 from nicovideo_api_client.api.v2.filter import SnapshotSearchAPIV2Filter
 from nicovideo_api_client.api.v2.json_filter import JsonFilterTerm, JsonFilterOperator
+from nicovideo_api_client.constants import FieldType
 
 
 class JsonFilterTestCase(unittest.TestCase):
-    term_time = JsonFilterTerm.set_range_time(
+    term_time = JsonFilterTerm.set_range(
+        FieldType.START_TIME,
         from_=datetime(2021, 1, 1),
         to_=datetime(2021, 12, 31),
         include_upper=True,
         include_lower=True,
     )
 
-    term_view = JsonFilterTerm.set_range_view(
-        from_=100, to_=1000, include_upper=True, include_lower=True
+    term_view = JsonFilterTerm.set_range(
+        FieldType.VIEW_COUNTER,
+        from_=100,
+        to_=1000,
+        include_upper=True,
+        include_lower=True,
     )
 
     def test_set_range_time(self):

--- a/tests/v2/test_json_filter.py
+++ b/tests/v2/test_json_filter.py
@@ -7,16 +7,16 @@ from nicovideo_api_client.constants import FieldType
 
 
 class JsonFilterTestCase(unittest.TestCase):
-    term_time = JsonFilterTerm.set_range(
-        FieldType.START_TIME,
+    term_time = JsonFilterTerm().set_range(
+        field_type=FieldType.START_TIME,
         from_=datetime(2021, 1, 1),
         to_=datetime(2021, 12, 31),
         include_upper=True,
         include_lower=True,
     )
 
-    term_view = JsonFilterTerm.set_range(
-        FieldType.VIEW_COUNTER,
+    term_view = JsonFilterTerm().set_range(
+        field_type=FieldType.VIEW_COUNTER,
         from_=100,
         to_=1000,
         include_upper=True,

--- a/tests/v2/test_request.py
+++ b/tests/v2/test_request.py
@@ -95,7 +95,6 @@ class SnapshotSearchAPIV2RequestTestCase(unittest.TestCase):
             "?targets=title&q=%E6%AD%8C%E3%81%A3%E3%81%A6%E3%81%BF%E3%81%9F"
             "+OR+%E8%B8%8A%E3%81%A3%E3%81%A6%E3%81%BF%E3%81%9F&fields=title&"
             "_sort=-viewCounter"
-
         )
 
     @staticmethod
@@ -223,8 +222,10 @@ class SnapshotSearchAPIV2RequestTestCase(unittest.TestCase):
             .sort(FieldType.VIEW_COUNTER)
             .json_filter(
                 JsonFilterOperator.not_(
-                    JsonFilterTerm.set_range_time(
-                        to_=datetime(2021, 1, 1, 0, 0, 0), include_upper=False
+                    JsonFilterTerm.set_range(
+                        FieldType.START_TIME,
+                        to_=datetime(2021, 1, 1, 0, 0, 0),
+                        include_upper=False,
                     )
                 )
             )

--- a/tests/v2/test_request.py
+++ b/tests/v2/test_request.py
@@ -222,7 +222,7 @@ class SnapshotSearchAPIV2RequestTestCase(unittest.TestCase):
             .sort(FieldType.VIEW_COUNTER)
             .json_filter(
                 JsonFilterOperator.not_(
-                    JsonFilterTerm().set_range(
+                    JsonFilterTerm.set_range(
                         FieldType.START_TIME,
                         to_=datetime(2021, 1, 1, 0, 0, 0),
                         include_upper=False,

--- a/tests/v2/test_request.py
+++ b/tests/v2/test_request.py
@@ -222,7 +222,7 @@ class SnapshotSearchAPIV2RequestTestCase(unittest.TestCase):
             .sort(FieldType.VIEW_COUNTER)
             .json_filter(
                 JsonFilterOperator.not_(
-                    JsonFilterTerm.set_range(
+                    JsonFilterTerm().set_range(
                         FieldType.START_TIME,
                         to_=datetime(2021, 1, 1, 0, 0, 0),
                         include_upper=False,


### PR DESCRIPTION
#11
json_filterの共通化について、共通化関数set_rangeを実装
json_のfieldが受け付けるフィールドについて引数field_type: FieldTypeで判定。
userId, channelId, viewCounter, mylistCounter, likeCounter, lengthSeconds, commentCounter：int型として受け取りfrom_, to_に格納
startTime, lastCommentTime：datetime型として受け取りISO8601形式としてfrom_, to_に格納
それ以外のフィールド：例外処理