### PR TITLE
no_filter の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ json = SnapshotSearchAPIV2() \
     .query("VOCALOID") \
     .field({FieldType.TITLE, FieldType.CONTENT_ID}) \
     .sort(FieldType.VIEW_COUNTER) \
-    .simple_filter().filter() \
+    .no_filter() \
     .limit(100) \
     .request() \
     .json()

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -10,8 +10,7 @@ def main():
         .query("VOCALOID")
         .field({FieldType.TITLE, FieldType.DESCRIPTION})
         .sort(FieldType.VIEW_COUNTER)
-        .simple_filter()
-        .filter()
+        .no_filter()
         .limit(100)
     )
 

--- a/nicovideo_api_client/api/v2/filter.py
+++ b/nicovideo_api_client/api/v2/filter.py
@@ -11,6 +11,9 @@ class SnapshotSearchAPIV2Filter:
     def __init__(self, query: Dict[str, str]):
         self._query: Dict[str, str] = query
 
+    def no_filter(self) -> SnapshotSearchAPIV2Limit:
+        return SnapshotSearchAPIV2Limit(self._query)
+
     def simple_filter(self) -> SnapshotSearchAPIV2SimpleFilter:
         """
         絞り込みにシンプルな `filters` を利用することを宣言する。

--- a/nicovideo_api_client/api/v2/filter.py
+++ b/nicovideo_api_client/api/v2/filter.py
@@ -12,6 +12,10 @@ class SnapshotSearchAPIV2Filter:
         self._query: Dict[str, str] = query
 
     def no_filter(self) -> SnapshotSearchAPIV2Limit:
+        if "q" not in self._query:
+            raise KeyError("キーワードが指定されていません")
+        elif self._query["q"] == "":
+            raise ValueError("キーワード無し検索を行う場合には必ず検索フィルタを指定してください")
         return SnapshotSearchAPIV2Limit(self._query)
 
     def simple_filter(self) -> SnapshotSearchAPIV2SimpleFilter:

--- a/tests/v2/test_filter.py
+++ b/tests/v2/test_filter.py
@@ -1,0 +1,12 @@
+import unittest
+
+from nicovideo_api_client.api.v2.snapshot_search_api_v2 import SnapshotSearchAPIV2
+from nicovideo_api_client.constants import FieldType
+
+
+class SnapshotSearchAPIV2FieldsTestCase(unittest.TestCase):
+    def test_no_keyword_no_filter(self):
+        with self.assertRaises(ValueError):
+            SnapshotSearchAPIV2().keywords().no_keyword().field({FieldType.TITLE}).sort(
+                FieldType.VIEW_COUNTER
+            ).no_filter()


### PR DESCRIPTION
`filters` および `jsonFilter` は省略可能だったため、 `no_filter` メソッドを追加した。

これまで、 `simple_filter().filter()` で実現していたことと動作的には同等。