### PR TITLE
sing_voice_synthesis_tags の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ from nicovideo_api_client.constants import FieldType
 
 json = SnapshotSearchAPIV2() \
     .tags_exact() \
-    .query("VOCALOID") \
+    .single_query("VOCALOID") \
     .field({FieldType.TITLE, FieldType.CONTENT_ID}) \
     .sort(FieldType.VIEW_COUNTER) \
     .no_filter() \
     .limit(100) \
-    .request() \
     .user_agent("NicoApiClient", "0.5.0") \
+    .request() \
     .json()
 ```
 

--- a/examples/and_or_search.py
+++ b/examples/and_or_search.py
@@ -10,7 +10,7 @@ def main():
     request = (
         SnapshotSearchAPIV2()
         .tags_exact()
-        .query("VOCALOID")
+        .query(["VOCALOID"])
         .and_(["初音ミク", "鏡音リン"])
         .and_(["MMD"])
         .field({FieldType.TITLE})

--- a/examples/json_filter.py
+++ b/examples/json_filter.py
@@ -10,7 +10,7 @@ def main():
     request = (
         SnapshotSearchAPIV2()
         .tags_exact()
-        .query("VOCALOID")
+        .single_query("VOCALOID")
         .field({FieldType.TITLE})
         .sort(FieldType.VIEW_COUNTER)
         .json_filter(

--- a/examples/multiple.py
+++ b/examples/multiple.py
@@ -7,7 +7,7 @@ def main():
     request = (
         SnapshotSearchAPIV2()
         .tags_exact()
-        .query("VOCALOID")
+        .single_query("VOCALOID")
         .field({FieldType.TITLE, FieldType.DESCRIPTION})
         .sort(FieldType.VIEW_COUNTER)
         .simple_filter()

--- a/examples/simple_filter.py
+++ b/examples/simple_filter.py
@@ -16,7 +16,7 @@ def main():
     request = (
         SnapshotSearchAPIV2()
         .tags_exact()
-        .query("VOCALOID")
+        .single_query("VOCALOID")
         .field(
             {
                 FieldType.TITLE,
@@ -51,7 +51,7 @@ def main():
     request = (
         SnapshotSearchAPIV2()
         .tags_exact()
-        .query("VOCALOID")
+        .single_query("VOCALOID")
         .field(
             {
                 FieldType.TITLE,
@@ -87,7 +87,7 @@ def main():
     request = (
         SnapshotSearchAPIV2()
         .tags_exact()
-        .query("VOCALOID")
+        .single_query("VOCALOID")
         .field(
             {
                 FieldType.TITLE,

--- a/examples/sing_voice_synthesis_tags.py
+++ b/examples/sing_voice_synthesis_tags.py
@@ -6,20 +6,14 @@ def main():
     # URL生成
     request = (
         SnapshotSearchAPIV2()
-        .tags_exact()
-        .single_query("VOCALOID")
-        .field({FieldType.TITLE, FieldType.DESCRIPTION})
+        .sing_voice_synthesis_tags()
+        .field({FieldType.TITLE})
         .sort(FieldType.VIEW_COUNTER)
         .no_filter()
-        .limit(1)
+        .limit(10)
         .user_agent("NicoApiClient", "0.5.0")
     )
 
-    # https://api.search.nicovideo.jp/api/v2/snapshot/video/contents/search?targets=tagsExact&q=VOCALOID&fields=contentId%2Ctitle&_sort=-viewCounter
-    print(request.build_url())
-
-    # 実行
-    # API のレスポンスが表示される
     print(request.request().json())
 
 

--- a/nicovideo_api_client/api/v2/snapshot_search_api_v2.py
+++ b/nicovideo_api_client/api/v2/snapshot_search_api_v2.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 import requests
 
+from nicovideo_api_client.api.v2.field import SnapshotSearchAPIV2Fields
 from nicovideo_api_client.api.v2.targets import SnapshotSearchAPIV2Targets
 from nicovideo_api_client.constants import END_POINT_URL_V2_VERSION, FieldType, target_types
 
@@ -32,6 +33,39 @@ class SnapshotSearchAPIV2:
         :return: クエリ(キーワード)入力オブジェクト
         """
         return SnapshotSearchAPIV2Targets(FieldType.TITLE, FieldType.DESCRIPTION, FieldType.TAGS)
+
+    @staticmethod
+    def sing_voice_synthesis_tags() -> SnapshotSearchAPIV2Fields:
+        """
+        VOCALOID・UTAUなどの歌声合成ソフトを利用した動画を検索するタグを用いて検索する。
+        タグの一覧は https://lit.link/avogado6 を参照。
+        :return: レスポンスフィールドのタイプ指定オブジェクト
+        """
+        sing_voice_synthesis_tag = [
+            "UTAU",
+            "VOCALOID",
+            "UTAUオリジナル曲",
+            "VOCALOIDオリジナル曲",
+            "VOICEROIDオリジナル曲",
+            "NEUTRINOオリジナル曲",
+            "CeVIOオリジナル曲",
+            "vocaloid新曲リンク",
+            "SynthesizerV",
+            "歌うa.i.voice",
+            "A.I.VOICEオリジナル曲",
+            "歌うボイスロイド",
+            "VOCALOIDインスト曲",
+            "ボカロオリジナル曲",
+            "ソフトウェアシンガー",
+            "UTAU新曲リンク",
+            "cevio新曲リンク",
+            "VOCALOID処女作",
+            "UTAU処女作",
+            "CeVIO処女作",
+            "neutrino(歌声合成エンジン)",
+        ]
+        exclude = ["ボカロオリジナルを歌ってみた"]
+        return SnapshotSearchAPIV2Targets(FieldType.TAGS_EXACT).query(sing_voice_synthesis_tag, exclude)
 
     @staticmethod
     def targets(targets: Set[FieldType]) -> SnapshotSearchAPIV2Targets:

--- a/nicovideo_api_client/api/v2/targets.py
+++ b/nicovideo_api_client/api/v2/targets.py
@@ -84,8 +84,13 @@ class SnapshotSearchAPIV2And(SnapshotSearchAPIV2Fields):
         :param keyword: クエリのqキーに指定するための文字列
         """
         # フレーズ検索かどうかの判定(" "は" OR "も含んでいる)
-        if ((keyword[0] != '"' and keyword[-1] != '"') and " " in keyword) or keyword[0] == "-":
-            keyword = '"' + keyword + '"'
+        if (
+            ((keyword[0] != '"' and keyword[-1] != '"') and " " in keyword)
+            or keyword[0] == "-"
+            or '"' in keyword
+            or "\\" in keyword
+        ):
+            keyword = '"' + keyword.replace("\\", "\\\\").replace('"', '\\"') + '"'
         elif keyword == "OR":
             keyword = '"OR"'
         if exclude:

--- a/nicovideo_api_client/api/v2/targets.py
+++ b/nicovideo_api_client/api/v2/targets.py
@@ -1,6 +1,7 @@
-from typing import Dict, Set, Union
+from typing import Dict, Optional, Set, Union
 
 from nicovideo_api_client.api.v2.field import SnapshotSearchAPIV2Fields
+from nicovideo_api_client.api.v2.sort import SnapshotSearchAPIV2Sort
 from nicovideo_api_client.constants import FieldType
 
 
@@ -31,7 +32,7 @@ class SnapshotSearchAPIV2Targets:
         self._query["q"] = keyword
         return SnapshotSearchAPIV2Fields(self._query)
 
-    def query(self, keyword: Union[str, list[str]]) -> "SnapshotSearchAPIV2And":
+    def query(self, keyword: list[str], exclude: Optional[list[str]] = None) -> "SnapshotSearchAPIV2And":
         """
         AND・OR検索を用いて検索クエリ(キーワード)を指定する。
 
@@ -39,13 +40,16 @@ class SnapshotSearchAPIV2Targets:
         %E3%82%AF%E3%82%A8%E3%83%AA%E6%96%87%E5%AD%97%E5%88%97%E4%BB%95%E6%A7%98>`_
         に沿った値を入力することで AND, OR 検索など複数のキーワードを含めた検索を行うことができる。
 
-        :param keyword: 検索するキーワード。文字列または文字列を要素に持つリスト。
+        :param exclude: NOT 検索で使用するキーワード
+        :param keyword: 検索するキーワード。文字列または文字列を要素に持つリスト。リストにする場合は OR で連結される。
         :return: レスポンスアンドのタイプ指定オブジェクト
         """
 
+        if exclude is None:
+            exclude = []
         if keyword == "":
             raise Exception("キーワードなし検索を行うにはno_keywordメソッドを指定する必要があります")
-        return SnapshotSearchAPIV2And(self._query).and_(keyword)
+        return SnapshotSearchAPIV2And(self._query, exclude).and_(keyword)
 
     def no_keyword(self) -> SnapshotSearchAPIV2Fields:
         """
@@ -62,29 +66,36 @@ class SnapshotSearchAPIV2Targets:
         return SnapshotSearchAPIV2Fields(self._query)
 
 
-class SnapshotSearchAPIV2And:
-    def __init__(self, query: Dict[str, str]):
-        self._query: Dict[str, str] = query
+class SnapshotSearchAPIV2And(SnapshotSearchAPIV2Fields):
+    def __init__(self, query: Dict[str, str], exclude: list[str]):
+        super().__init__(query)
+        self.exclude = exclude
 
-    def field(self, fields: Set[FieldType]):
-        return SnapshotSearchAPIV2Fields(self._query).field(fields)
+    def field(self, fields: Set[FieldType]) -> SnapshotSearchAPIV2Sort:
+        if self._query["q"] == "":
+            raise Exception("NOT検索のみを実行することはできません")
+        for e in self.exclude:
+            self._arrange_keyword(e, exclude=True)
+        return super().field(fields)
 
-    def _arrange_keyword(self, keyword: str):
+    def _arrange_keyword(self, keyword: str, exclude: bool = False):
         """
         キーワードを適切な形でクエリに指定する。
         :param keyword: クエリのqキーに指定するための文字列
         """
         # フレーズ検索かどうかの判定(" "は" OR "も含んでいる)
-        if (keyword[0] != '"' and keyword[-1] != '"') and " " in keyword:
-            raise Exception("検索ワードに半角スペースが含まれています")
+        if ((keyword[0] != '"' and keyword[-1] != '"') and " " in keyword) or keyword[0] == "-":
+            keyword = '"' + keyword + '"'
         elif keyword == "OR":
             keyword = '"OR"'
+        if exclude:
+            keyword = "-" + keyword
         if "q" not in self._query.keys():
             self._query["q"] = keyword
         else:
             self._query["q"] += " " + keyword
 
-    def and_(self, keyword: Union[str, list[str]]):
+    def and_(self, keyword: Union[str, list[str]]) -> "SnapshotSearchAPIV2And":
         if type(keyword) is str:
             self._arrange_keyword(keyword)
         elif type(keyword) is list:

--- a/nicovideo_api_client/api/v2/targets.py
+++ b/nicovideo_api_client/api/v2/targets.py
@@ -41,7 +41,7 @@ class SnapshotSearchAPIV2Targets:
         に沿った値を入力することで AND, OR 検索など複数のキーワードを含めた検索を行うことができる。
 
         :param exclude: NOT 検索で使用するキーワード
-        :param keyword: 検索するキーワード。文字列または文字列を要素に持つリスト。リストにする場合は OR で連結される。
+        :param keyword: 検索するキーワード。文字列を要素に持つリストの形式になっており、複数要素があれば OR で連結される。
         :return: レスポンスアンドのタイプ指定オブジェクト
         """
 
@@ -96,6 +96,11 @@ class SnapshotSearchAPIV2And(SnapshotSearchAPIV2Fields):
             self._query["q"] += " " + keyword
 
     def and_(self, keyword: Union[str, list[str]]) -> "SnapshotSearchAPIV2And":
+        """
+        AND 検索に利用する。
+        NOT 検索に必要なパラメータは `query()` で指定する。
+        :param keyword: 検索するキーワード。文字列または文字列を要素に持つリスト。リストにする場合は OR で連結される。
+        """
         if type(keyword) is str:
             self._arrange_keyword(keyword)
         elif type(keyword) is list:

--- a/nicovideo_api_client/api/v2/targets.py
+++ b/nicovideo_api_client/api/v2/targets.py
@@ -47,7 +47,7 @@ class SnapshotSearchAPIV2Targets:
 
         if exclude is None:
             exclude = []
-        if keyword == "":
+        if type(keyword) is not list or len(keyword) < 1:
             raise Exception("キーワードなし検索を行うにはno_keywordメソッドを指定する必要があります")
         return SnapshotSearchAPIV2And(self._query, exclude).and_(keyword)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.taskipy.tasks]
 example = "python examples/example.py"
-test = "pytest tests"
+test = "pytest tests -vv"
 docs = "sh script/make-docs.sh"
 lint = "poetry run pflake8 nicovideo_api_client examples tests"
 format = "poetry run black --target-version py310 nicovideo_api_client examples tests && poetry run isort nicovideo_api_client examples tests"

--- a/tests/v2/test_request.py
+++ b/tests/v2/test_request.py
@@ -290,7 +290,7 @@ class SnapshotSearchAPIV2RequestTestCase(unittest.TestCase):
         actual = (
             SnapshotSearchAPIV2()
             .targets({FieldType.TITLE})
-            .query("テスト")
+            .single_query("テスト")
             .field({FieldType.TITLE})
             .sort(FieldType.VIEW_COUNTER)
             .simple_filter()

--- a/tests/v2/test_request.py
+++ b/tests/v2/test_request.py
@@ -35,7 +35,7 @@ class SnapshotSearchAPIV2RequestTestCase(unittest.TestCase):
         actual = (
             SnapshotSearchAPIV2()
             .targets({FieldType.TITLE})
-            .query("テスト")
+            .single_query("テスト")
             .field({FieldType.TITLE})
             .sort(FieldType.VIEW_COUNTER)
             .simple_filter()
@@ -54,7 +54,7 @@ class SnapshotSearchAPIV2RequestTestCase(unittest.TestCase):
         actual = (
             SnapshotSearchAPIV2()
             .targets({FieldType.TITLE})
-            .query("歌ってみた")
+            .query(["歌ってみた"])
             .and_(["初音ミク", "鏡音リン"])
             .field({FieldType.TITLE})
             .sort(FieldType.VIEW_COUNTER)
@@ -105,7 +105,7 @@ class SnapshotSearchAPIV2RequestTestCase(unittest.TestCase):
         actual = (
             SnapshotSearchAPIV2()
             .targets({FieldType.TITLE})
-            .query("歌ってみた")
+            .single_query("歌ってみた")
             .field(
                 {
                     FieldType.TITLE,
@@ -144,7 +144,7 @@ class SnapshotSearchAPIV2RequestTestCase(unittest.TestCase):
         actual = (
             SnapshotSearchAPIV2()
             .targets({FieldType.TITLE})
-            .query("歌ってみた")
+            .single_query("歌ってみた")
             .field(
                 {
                     FieldType.TITLE,
@@ -183,7 +183,7 @@ class SnapshotSearchAPIV2RequestTestCase(unittest.TestCase):
         actual = (
             SnapshotSearchAPIV2()
             .targets({FieldType.TITLE})
-            .query("歌ってみた")
+            .single_query("歌ってみた")
             .field(
                 {
                     FieldType.TITLE,
@@ -213,7 +213,7 @@ class SnapshotSearchAPIV2RequestTestCase(unittest.TestCase):
         actual = (
             SnapshotSearchAPIV2()
             .targets({FieldType.TITLE})
-            .query("テスト")
+            .single_query("テスト")
             .field({FieldType.TITLE})
             .sort(FieldType.VIEW_COUNTER)
             .json_filter(
@@ -253,7 +253,7 @@ class SnapshotSearchAPIV2RequestTestCase(unittest.TestCase):
         actual = (
             SnapshotSearchAPIV2()
             .targets({FieldType.TITLE})
-            .query("テスト")
+            .single_query("テスト")
             .field({FieldType.TITLE})
             .sort(FieldType.VIEW_COUNTER)
             .simple_filter()

--- a/tests/v2/test_snapshot_search_api_v2.py
+++ b/tests/v2/test_snapshot_search_api_v2.py
@@ -17,6 +17,17 @@ class SnapshotSearchAPIV2TestCase(unittest.TestCase):
         instance = SnapshotSearchAPIV2().keywords()
         assert instance._query == {"targets": "title,description,tags"}
 
+    @staticmethod
+    def test_sing_voice_synthesis_tags():
+        instance = SnapshotSearchAPIV2().sing_voice_synthesis_tags().field(set())
+        assert instance._query == {
+            "targets": "tagsExact",
+            "q": "UTAU OR VOCALOID OR UTAUオリジナル曲 OR VOCALOIDオリジナル曲 OR VOICEROIDオリジナル曲 OR NEUTRINOオリジナル曲 OR "
+            "CeVIOオリジナル曲 OR vocaloid新曲リンク OR SynthesizerV OR 歌うa.i.voice OR A.I.VOICEオリジナル曲 OR 歌うボイスロイド OR "
+            "VOCALOIDインスト曲 OR ボカロオリジナル曲 OR ソフトウェアシンガー OR UTAU新曲リンク OR cevio新曲リンク OR VOCALOID処女作 OR UTAU処女作 OR "
+            "CeVIO処女作 OR neutrino(歌声合成エンジン) -ボカロオリジナルを歌ってみた",
+        }
+
     def test_targets_success(self):
         for t in target_types:
             with self.subTest(t.value):

--- a/tests/v2/test_targets.py
+++ b/tests/v2/test_targets.py
@@ -14,9 +14,47 @@ class SnapshotSearchAPIV2TargetsTestCase(unittest.TestCase):
         assert "targets が設定されていません" == str(e.value)
 
     @staticmethod
+    def test_single_query():
+        expected = "keyword"
+        assert SnapshotSearchAPIV2Targets(FieldType.TITLE).single_query(expected)._query["q"] == expected
+
+    @staticmethod
     def test_query():
         expected = "keyword"
-        assert SnapshotSearchAPIV2Targets(FieldType.TITLE).query(expected)._query["q"] == expected
+        assert SnapshotSearchAPIV2Targets(FieldType.TITLE).query([expected])._query["q"] == expected
+
+    @staticmethod
+    def test_query_and():
+        expected = "VOCALOID UTAU"
+        assert SnapshotSearchAPIV2Targets(FieldType.TITLE).query(["VOCALOID"]).and_("UTAU")._query["q"] == expected
+
+    @staticmethod
+    def test_query_and_or():
+        expected = "VOCALOID OR UTAU SynthesizerV"
+        assert (
+            SnapshotSearchAPIV2Targets(FieldType.TITLE).query(["VOCALOID", "UTAU"]).and_("SynthesizerV")._query["q"]
+            == expected
+        )
+
+    @staticmethod
+    def test_query_and_or_not():
+        expected = "VOCALOID OR UTAU SynthesizerV -CeVIO"
+        assert (
+            SnapshotSearchAPIV2Targets(FieldType.TITLE)
+            .query(["VOCALOID", "UTAU"], ["CeVIO"])
+            .and_("SynthesizerV")
+            .field(set())
+            ._query["q"]
+            == expected
+        )
+
+    @staticmethod
+    def test_query_or_not():
+        expected = "VOCALOID OR UTAU -CeVIO"
+        assert (
+            SnapshotSearchAPIV2Targets(FieldType.TITLE).query(["VOCALOID", "UTAU"], ["CeVIO"]).field(set())._query["q"]
+            == expected
+        )
 
 
 if __name__ == "__main__":

--- a/tests/v2/test_targets.py
+++ b/tests/v2/test_targets.py
@@ -24,6 +24,26 @@ class SnapshotSearchAPIV2TargetsTestCase(unittest.TestCase):
         assert SnapshotSearchAPIV2Targets(FieldType.TITLE).query([expected])._query["q"] == expected
 
     @staticmethod
+    def test_query_escape_space():
+        expected = '"1 2"'
+        assert SnapshotSearchAPIV2Targets(FieldType.TITLE).query(["1 2"])._query["q"] == expected
+
+    @staticmethod
+    def test_query_escape_or():
+        expected = '"OR"'
+        assert SnapshotSearchAPIV2Targets(FieldType.TITLE).query(["OR"])._query["q"] == expected
+
+    @staticmethod
+    def test_query_escape_double_quote():
+        expected = '"\\"keyword\\""'
+        assert SnapshotSearchAPIV2Targets(FieldType.TITLE).query(['"keyword"'])._query["q"] == expected
+
+    @staticmethod
+    def test_query_escape_double_backslash():
+        expected = '"keyword\\\\"'
+        assert SnapshotSearchAPIV2Targets(FieldType.TITLE).query(["keyword\\"])._query["q"] == expected
+
+    @staticmethod
     def test_query_and():
         expected = "VOCALOID UTAU"
         assert SnapshotSearchAPIV2Targets(FieldType.TITLE).query(["VOCALOID"]).and_("UTAU")._query["q"] == expected

--- a/tests/v2/test_user_agent.py
+++ b/tests/v2/test_user_agent.py
@@ -7,16 +7,16 @@ from nicovideo_api_client.constants import FieldType
 class SnapshotSearchAPIV2UserAgentTestCase(unittest.TestCase):
     def undefined_user_agent_product(self):
         with self.assertRaises(ValueError) as error:
-            SnapshotSearchAPIV2().targets({FieldType.TITLE}).query("テスト").field({FieldType.TITLE}).sort(
+            SnapshotSearchAPIV2().targets({FieldType.TITLE}).single_query("テスト").field({FieldType.TITLE}).sort(
                 FieldType.VIEW_COUNTER
-            ).simple_filter().filter().limit(10).user_agent(version="0.5.0")
+            ).simple_filter().filter().limit(10).user_agent(product="NicoApiClient", version="0.5.0")
         self.assertEqual(error.exception.args[0], "User-Agentのプロダクト名の指定は必須です")
 
     def undefined_user_agent_version(self):
         with self.assertRaises(ValueError) as error:
-            SnapshotSearchAPIV2().targets({FieldType.TITLE}).query("テスト").field({FieldType.TITLE}).sort(
+            SnapshotSearchAPIV2().targets({FieldType.TITLE}).single_query("テスト").field({FieldType.TITLE}).sort(
                 FieldType.VIEW_COUNTER
-            ).simple_filter().filter().limit(10).user_agent(product="NicoApiClient")
+            ).simple_filter().filter().limit(10).user_agent(product="NicoApiClient", version="0.5.0")
         self.assertEqual(error.exception.args[0], "User-Agentのプロダクトバージョンの指定は必須です")
 
 


### PR DESCRIPTION
close #60

`SnapshotSearchAPIV2Targets#query` に NOT検索用引数の `exclude` を追加した。
`keyword` に文字列型を許容すると、 `query(['A', 'B'])` と書きたいところを `query('A', 'B')` と書いた時に静的解析に拾われず、バグ発見の妨げになりそうなので、 `list[str]` に変更した。
これまで `SnapshotSearchAPIV2Targets#query(str)` を利用していた箇所は `SnapshotSearchAPIV2Targets#single_query` への置き換えが必要。

`SnapshotSearchAPIV2Targets#query` で ``  が含まれる文字列、 `-` から始まる文字列、もしくは  `”OR”` が `"` で囲まれるようになりました。