### PR TITLE
ci: poetry のインストールコマンドを修正する

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.10'
       - name: Install Poetry
         run: |
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+          curl -sSL https://install.python-poetry.org | python3 -
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Install Dependencies
         run: poetry install --no-interaction


### PR DESCRIPTION
https://github.com/python-poetry/poetry/issues/6676

> The get-poetry.py installer has been deprecated and removed. If you installed Poetry using get-poetry.py, please uninstall (as documented in the relevant step below), and then follow these installation instructions.
> 
> The previous install-poetry.py script as included in the Poetry repository is deprecated and frozen. Please migrate to the standalone version described above, as the in-tree version is [scheduled to be removed](https://github.com/python-poetry/poetry/issues/6676).

```bash
curl -sSL https://install.python-poetry.org | python3 -
```